### PR TITLE
Makefiles for SDLC orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,175 @@
+# Fork from https://github.com/docker-production-aws/microtrader/blob/master/Makefile
+
+# MIT License
+
+# Copyright (c) 2019 Jimmy Herrera
+# Copyright (c) 2017 Justin Menga
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Import local environment overrides
+$(shell touch .env)
+include .env
+
+# Project variables
+PROJECT_NAME ?= timeoff
+PROJECT_NAMESPACE ?= arruko
+DOCKER_IMAGE_NAME ?= timeoff
+DOCKER_IMAGE_TEST_NAME ?= timeoff-dev
+DOCKER_IMAGE_BASE_NAME ?= timeoff-base
+
+# AWS ECR settings
+AWS_ACCOUNT_ID ?= 184432115055
+AWS_ZONE ?= us-east-2
+DOCKER_REGISTRY ?= "$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_ZONE).amazonaws.com"
+DOCKER_LOGIN_EXPRESSION := eval $$(aws ecr get-login --registry-ids $(AWS_ACCOUNT_ID) --no-include-email)
+
+# Release settings
+export HTTP_PORT ?= 3000
+export DB_NAME ?= $(PROJECT_NAME)
+export DB_USER ?= root
+export DB_PASSWORD ?= null
+export BUILD_ID ?=
+export NODE_VERSION ?= 6.14.0
+export PHANTOMJS_VERSION ?= 2.1.1
+export TEST_MODE ?= phantomjs # chrome | phantomjs
+export AWS_PROFILE ?= timeoff-admin
+
+# Common settings
+include Makefile.settings
+
+.PHONY: version base test build release clean tag tag%default login logout publish compose dcompose database save load demo all
+
+# Prints version
+version:
+	@ echo '{"Version": "$(APP_VERSION)"}'
+
+# Runs base images build
+# Pulls images and base images by default
+base: login
+	${INFO} "Build base images for release"
+	@ docker build -f docker/base/Dockerfile.release -t $(DOCKER_IMAGE_BASE_NAME)-release:latest .
+	${INFO} "Build base images for test"
+	@ docker build -f docker/base/Dockerfile.test -t $(DOCKER_IMAGE_BASE_NAME)-test:latest .
+	${INFO} "Tag images with docker registry"
+	@ docker tag $(DOCKER_IMAGE_BASE_NAME)-test:latest $(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)/$(DOCKER_IMAGE_BASE_NAME)-test:latest
+	@ docker tag $(DOCKER_IMAGE_BASE_NAME)-release:latest $(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)/$(DOCKER_IMAGE_BASE_NAME)-release:latest
+	${INFO} "Publish images to docker registry"
+	@ docker push "$(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)/$(DOCKER_IMAGE_BASE_NAME)-test:latest"
+	@ docker push "$(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)/$(DOCKER_IMAGE_BASE_NAME)-release:latest"
+	${INFO} "Base images complete"
+
+# Runs unit and integration tests
+# Pulls images and base images by default
+# Use 'make test :nopull' to disable default pull behaviour
+test:
+	${INFO} "Building images..."
+	@ docker-compose $(TEST_ARGS) build $(NOPULL_FLAG) timeoff test
+	${INFO} "Running tests..."
+	@ docker-compose $(TEST_ARGS) up --abort-on-container-exit --exit-code-from test timeoff test 
+	${INFO} "Checking test results..."
+	@ $(call check_exit_code,$(TEST_ARGS),test)
+	${INFO} "Test complete"
+
+# Builds release image and runs acceptance tests
+# Use 'make release :nopull' to disable default pull behaviour
+release:
+	${INFO} "Building images..."
+	@ docker-compose $(RELEASE_ARGS) build $(NOPULL_FLAG) db timeoff
+	${INFO} "Starting timeoff database..."
+	@ docker-compose $(RELEASE_ARGS) up -d db
+	@ $(call check_service_health,$(RELEASE_ARGS),db)
+	${INFO} "Starting timeoff service..."
+	@ docker-compose $(RELEASE_ARGS) up -d timeoff
+	@ $(call check_service_health,$(RELEASE_ARGS),timeoff)
+	${INFO} "Acceptance testing complete"
+	${INFO} "Timeoff is running at http://$(DOCKER_HOST_IP):$(call get_port_mapping,$(RELEASE_ARGS),timeoff,$(HTTP_PORT))"
+
+# Executes a full workflow
+all: clean base test release tag-default publish clean
+
+# Cleans environment
+clean: clean-test clean-release
+	${INFO} "Removing dangling images..."
+	@ $(call clean_dangling_images,$(DOCKER_IMAGE_BASE_NAME))
+	@ $(call clean_dangling_images,$(DOCKER_IMAGE_NAME))
+	@ $(call clean_dangling_images,$(DOCKER_IMAGE_TEST_NAME))
+	${INFO} "Clean complete"
+
+clean%test:
+	${INFO} "Destroying test environment..."
+	@ docker-compose $(TEST_ARGS) down -v || true
+
+clean%release:
+	${INFO} "Destroying release environment..."
+	@ docker-compose $(RELEASE_ARGS) down -v || true
+
+# 'make tag <tag> [<tag>...]' tags development and/or release image with specified tag(s)
+tag:
+	${INFO} "Tagging development image with tags $(TAG_ARGS)..."
+	@ $(foreach tag,$(TAG_ARGS),$(call tag_image,$(TEST_ARGS),test,$(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)/$(DOCKER_IMAGE_TEST_NAME):$(tag));)
+	${INFO} "Tagging release images with tags $(TAG_ARGS)..."
+	@ $(foreach tag,$(TAG_ARGS),$(call tag_image,$(RELEASE_ARGS),timeoff,$(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)/$(DOCKER_IMAGE_NAME):$(tag));)
+	${INFO} "Tagging complete"
+
+# Tags with default set of tags
+tag%default:
+	@ make tag latest $(APP_VERSION) $(COMMIT_ID) $(COMMIT_TAG)
+
+# Login to Docker registry
+login:
+	${INFO} "Logging in to Docker registry $$DOCKER_REGISTRY..."
+	@ $(DOCKER_LOGIN_EXPRESSION)
+	${INFO} "Logged in to Docker registry $$DOCKER_REGISTRY"
+
+# Logout of Docker registry
+logout:
+	${INFO} "Logging out of Docker registry $$DOCKER_REGISTRY..."
+	@ docker logout
+	${INFO} "Logged out of Docker registry $$DOCKER_REGISTRY"
+
+# Publishes image(s) tagged using make tag commands
+publish:
+	${INFO} "Publishing release images to $(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)..."
+	@ $(call publish_image,$(RELEASE_ARGS),timeoff,$(DOCKER_REGISTRY)/$(PROJECT_NAMESPACE)/$(DOCKER_IMAGE_NAME))
+	${INFO} "Publish complete"
+
+# Executes docker-compose commands in release environment
+#   e.g. 'make compose ps' is the equivalent of docker-compose -f path/to/dockerfile -p <project-name> ps
+#   e.g. 'make compose run nginx' is the equivalent of docker-compose -f path/to/dockerfile -p <project-name> run nginx
+#
+# Use '--'' after make to pass flags/arguments
+#   e.g. 'make -- compose run --rm nginx' ensures the '--rm' flag is passed to docker-compose and not interpreted by make
+compose:
+	${INFO} "Running docker-compose command in release environment..."
+	@ docker-compose -p $(REL_PROJECT) -f $(REL_COMPOSE_FILE) $(ARGS)
+
+# Executes docker-compose commands in test environment
+#   e.g. 'make dcompose ps' is the equivalent of docker-compose -f path/to/dockerfile -p <project-name> ps
+#   e.g. 'make dcompose run test' is the equivalent of docker-compose -f path/to/dockerfile -p <project-name> run test
+#
+# Use '--'' after make to pass flags/arguments
+#   e.g. 'make -- compose run --rm test' ensures the '--rm' flag is passed to docker-compose and not interpreted by make
+dcompose:
+	${INFO} "Running docker-compose command in test environment..."
+	@ docker-compose -p $(TEST_PROJECT) -f $(TEST_COMPOSE_FILE) $(ARGS)
+
+# IMPORTANT - ensures arguments are not interpreted as make targets
+%:
+	@:

--- a/Makefile.settings
+++ b/Makefile.settings
@@ -1,0 +1,131 @@
+# Fork from https://github.com/docker-production-aws/microtrader/blob/master/Makefile.settings
+
+# MIT License
+
+# Copyright (c) 2017 Justin Menga
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+#### STANDARD SETTINGS ####
+
+# Filenames
+DOCKER_COMPOSE_TEST_FILE := docker/test/docker-compose.yml
+DOCKER_COMPOSE_RELEASE_FILE := docker/release/docker-compose.yml
+
+# Docker Compose Project Names
+PROJECT_RELEASE_NAME := $(PROJECT_NAME)$(BUILD_ID)
+PROJECT_TEST_NAME := $(PROJECT_RELEASE_NAME)-test
+
+# Use these settings to specify a custom Docker registry
+DOCKER_REGISTRY ?= docker.io
+
+# WARNING: Set DOCKER_REGISTRY_AUTH to empty for Docker Hub
+# Set DOCKER_REGISTRY_AUTH to auth endpoint for private Docker registry
+DOCKER_REGISTRY_AUTH ?=
+
+# Expression to login to Docker registry
+DOCKER_LOGIN_EXPRESSION ?= docker login -u $$DOCKER_USER -p $$DOCKER_PASSWORD $(DOCKER_REGISTRY_AUTH)
+
+# Arguments
+NOPULL_ARG = $(findstring :nopull,$(ARGS))
+VERBOSE_ARG = $(findstring :verbose,$(ARGS))
+RELEASE_ARGS = -p $(PROJECT_RELEASE_NAME) -f $(DOCKER_COMPOSE_RELEASE_FILE) $(VERBOSE_FLAG)
+TEST_ARGS = -p $(PROJECT_TEST_NAME) -f $(DOCKER_COMPOSE_TEST_FILE) $(VERBOSE_FLAG)
+VERBOSE_FLAG = $(if $(VERBOSE_ARG),--verbose,)
+NOPULL_FLAG = $(if $(NOPULL_ARG),,--pull)
+
+# Set shell
+SHELL=/bin/bash -e -o pipefail
+
+# App version settings
+COMMIT_TIMESTAMP := $(shell echo $$(git log -1 --pretty='format:%cd' --date='format:%Y%m%d%H%M%S' 2>/dev/null))
+COMMIT_ID := $(shell echo $$(git rev-parse --short HEAD 2>/dev/null))
+COMMIT_TAG := $(shell echo $$(git tag --points-at HEAD 2>/dev/null))
+export APP_VERSION ?= $(COMMIT_TIMESTAMP).$(COMMIT_ID)$(if $(BUILD_ID),.$(BUILD_ID),)
+
+# Docker host settings
+DOCKER_HOST_IP := $(shell echo $$DOCKER_HOST | awk -F/ '{printf $$3}' | awk -F: '{printf $$1}')
+DOCKER_HOST_IP := $(if $(DOCKER_HOST_IP),$(DOCKER_HOST_IP),localhost)
+
+# Cosmetics
+RED := "\e[1;31m"
+YELLOW := "\e[1;33m"
+NC := "\e[0m"
+INFO := @bash -c 'printf $(YELLOW); echo "=> $$1"; printf $(NC)' MESSAGE
+WARNING := @bash -c 'printf $(RED); echo "WARNING: $$1"; printf $(NC)' MESSAGE
+
+# Extract extra arguments
+ifeq ($(firstword $(MAKECMDGOALS)),$(filter $(firstword $(MAKECMDGOALS)),release test clean compose dcompose))
+  ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+endif
+
+# Extract tag arguments
+ifeq ($(firstword $(MAKECMDGOALS)),$(filter $(firstword $(MAKECMDGOALS)),tag))
+  TAG_ARGS_RAW := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifeq ($(TAG_ARGS_RAW),)
+    $(error You must specify a tag)
+  endif
+  TAG_ARGS += $(foreach tag,$(TAG_ARGS_RAW),$(shell echo $(tag) | sed -e 's/[^a-zA-Z0-9\.\-]/_/g'))
+endif
+
+# Image and Repository Tag introspection functions
+# Syntax: $(call get_image_id,<docker-compose-environment>,<service-name>)
+# Syntax: $(call get_repo_tags,<docker-compose-environment>,<service-name>,<fully-qualified-image-name>)
+get_container_id = $$(docker-compose $(1) ps -q $(2))
+get_image_id = $$(echo $(call get_container_id,$(1),$(2)) | xargs -I ARGS docker inspect -f '{{ .Image }}' ARGS)
+get_container_state = $$(echo $(call get_container_id,$(1),$(2)) | xargs -I ID docker inspect -f '$(3)' ID)
+filter_repo_tags = $(if $(findstring docker.io,$(1)),$(subst docker.io/,,$(1))[^[:space:]|\$$]*,$(1)[^[:space:]|\$$]*)
+get_repo_tags = $$(echo $(call get_image_id,$(1),$(2)) | xargs -I ID docker inspect -f '{{range .RepoTags}}{{.}} {{end}}' ID | grep -oh "$(call filter_repo_tags,$(3))" | xargs)
+
+# Port introspection functions
+# Syntax: $(call get_port_mapping,<docker-compose-environment>,<service-name>,<internal-port>)
+get_raw_port_mapping = $$(docker-compose $(1) ps -q $(2) | xargs -I ID docker port ID $(3))
+get_port_mapping = $$(echo $$(IFS=':' read -r -a array <<< "$(call get_raw_port_mapping,$(1),$(2),$(3))" && echo "$${array[1]}"))
+
+# Service health functions
+# Syntax: $(call check_service_health,<docker-compose-environment>,<service-name>)
+get_service_health = $$(echo $(call get_container_state,$(1),$(2),{{if .State.Running}}{{ .State.Health.Status }}{{end}}))
+check_service_health = { \
+  until [[ $(call get_service_health,$(1),$(2)) != starting ]]; \
+    do sleep 1; \
+  done; \
+  if [[ $(call get_service_health,$(1),$(2)) != healthy ]]; \
+    then echo $(2) failed health check; exit 1; \
+  fi; \
+}
+
+# Tagging and Publishing functions
+# Syntax: $(call tag_image,<docker-compose-environment>,<service-name>,<fully-qualified-tag>)
+# Syntax: $(call publish_image,<docker-compose-environment>,<service-name>,<fully-qualified-repository>)
+tag_image = $$(echo $(call get_image_id,$(1),$(2)) | xargs -I ARG docker tag ARG $(3);)
+publish_image = { \
+	for tag in $(call get_repo_tags,$(1),$(2),$(3)); \
+		do echo $$tag | xargs -I TAG docker push TAG; \
+	done; \
+}
+
+# Exit code function
+# Syntax: $(call get_exit_code,<docker-compose-environment>,<service-name>)
+get_exit_code = $$(echo $(call get_container_state,$(1),$(2),{{ .State.ExitCode }}))
+check_exit_code = exit $(call get_exit_code,$(1),$(2))
+
+# Dangling image function
+# Syntax: $(call clean_dangling_images,<repository>)
+clean_dangling_images = docker images -q -f dangling=true -f label=application=$(1) | xargs -I ARGS docker rmi -f ARGS || true


### PR DESCRIPTION
Add ```make``` files for SDLC orchestration including: 

1. clean
2. base
3. test
4. release
5. tag
6. publish

Theses files will be used for AWS pipelines for project deployment.